### PR TITLE
Update advanced.rst

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -29,7 +29,7 @@ PhytoOracle makes it easy to swap between extractors. To being swapping, edit th
 
 Editing our workflow 
 ~~~~~~~~~~~~~~~~~~~~
-1. Begin by stating the rules, including the command and the inputs/outputs of your extractor. 
+1. The makeflow jx needs rules, including the command and the inputs/outputs of your extractor under the "rules" section.
 
 .. code-block:: RST
    
@@ -44,6 +44,56 @@ Editing our workflow
     }
 |
 
+The first part of phytoOracle uses a makeflow file to run a shell script to access singularity containers. 
+
+Looking at the stereoTop makeflow jx file main_workflow_phase1.jx for example: 
+
+.. code-block:: python
+  "rules": [
+    {
+      # processing for a single set of data (from cleanmetadata to soilmask)
+      "command": "./process_one_set.sh",
+      "environment": {
+        "RAW_DATA_PATH": DATA_SET["PATH"],
+        "UUID": DATA_SET["UUID"]
+      },
+      
+The command section contains an execution of the process_one_set.sh script.
+
+Lets take a look at execution within the process_one_set.sh:
+
+.. code-block:: BASH
+    singularity run -B $(pwd):/mnt --pwd /mnt docker://agpipeline/bin2tif:latest --result print --metadata ${METADATA} --working_space ${WORKING_SPACE} ${LEFT_BIN}
+    
+This is where the extractors are run as singularity containers. Makeflow will run the script as many times as you tell it to. If you run multiple containers per script, then they should all run every time the command within the "rules" is set to run. Either once per "command" or once for every variable in a certain range in a loop 
+
+Remember to include any input files the extractor will need
+
+.. code-bock:: python 
+
+      "inputs": [
+        "process_one_set.sh",
+        DATA_SET["PATH"] + DATA_SET["UUID"] + "_metadata.json",
+        "cached_betydb/bety_experiments.json",
+        DATA_SET["PATH"] + DATA_SET["UUID"] + "_left.bin",
+        DATA_SET["PATH"] + DATA_SET["UUID"] + "_right.bin"
+      ],
+      "outputs": [
+        CLEANED_META_DIR + DATA_SET["UUID"] + "_metadata_cleaned.json",
+        SOILMASK_DIR + DATA_SET["UUID"] + "_left_mask.tif",
+        SOILMASK_DIR + DATA_SET["UUID"] + "_right_mask.tif"
+      ]
+    } for DATA_SET in DATA_FILE_LIST,  ### This will loop through each data file in the list
+    
+Makeflow also lets you create, move or delete files or directories as you run the extractors and generate data.
+
+.. code-block:: BASH
+
+      "rules": [
+    {
+      # Make directory to store FIELDMOSAIC files
+      "command": "mkdir -p ${FIELDMOSAIC_DIR}",
+      
 Defining your values
 ~~~~~~~~~~~~~~~~~~~~
 2. Define elements of your workflow:
@@ -58,31 +108,30 @@ Defining your values
            # Rules you created above go here
        ]
    }
-   
-+ Continuing from the example in Step 1:
 
-.. code-block:: RST 
+Defining rules rules allows you to specify directory names or an RANGEs in loops
 
-    { 
-    "define":{
-                "message" : "hello world!"
-             },
-    "rules": [
-                {
-                    "command": "/bin/echo " +message+ " > output-from-define.txt",
-                    "outputs": [ "output-from-define.txt" ],
-                    "inputs":  [ ],
-                }
-             ]
-    }
+.. code-block:: python
+
+  "define": {
+    "CLEANED_META_DIR": "cleanmetadata_out/",
+    "SOILMASK_DIR": "soil_mask_out/",
+    "FIELDMOSAIC_DIR": "fieldmosaic_out/",
+    "MOSAIC_BOUNDS": "-111.9750963 33.0764953 -111.9747967 33.074485715",
+    "CANOPYCOVER_DIR": "canopy_cover_out/"
+  },
+  
+This is usefull for specifying ranges such as the DATA_FILE_LIST used above.
+
+
 
 Running your workflow 
 ~~~~~~~~~~~~~~~~~~~~~
-3. Now you can run it locally!
+3. Normally, to run a makeflow file locally you will need to include --jx when running makeflow to specify that the file is in JX format. 
 
 .. code-block:: RST
     
-    $ makeflow --jx define-hello.jx
+    $ makeflow --jx hello-makeflow.jx
     
     parsing define-hello.jx...
     local resources: 4 cores, 7764 MB memory, 2097151 MB disk
@@ -94,12 +143,24 @@ Running your workflow
     submitted job 1376
     job 1376 completed
     
-+ Then run the following: 
 
-.. code-block:: RST 
-    
-    $ cat output-from-define.txt 
-    hello world!
+Lets see what happend when we ran the entrypoint.sh script: 
+
+.. code-block:: BASH
+
+    makeflow -T wq --json main_workflow_phase1.json -a -N phyto_oracle-atmo -p 9123 -dall -o dall.log $@
+
+In this case we used --json to run the main_workflow_phase1.json, -T wq to broadcast the job to workqueue, -a to include it in the catalog server under the name phyto_oracle-atmo
+
+
+The "command" section was received by any machine that was conneced using:
+
+.. code-block:: BASH
+
+    work_queue_factory -T local IP_ADDRESS 9123 -w 40 -W 44 --workers-per-cycle 10  -E "-b 20 --wall-time=3600" --cores=1 --memory=2000 --disk 10000 -dall -t 900
+
+That command was the process_one_set.sh script which ran those singularity containers containing the extractors. 
+
 Creating Multiple Jobs
 ~~~~~~~~~~~~~~~~~~~~~~
 Workflows enable you to run analysis codes. Below is an example of how to string multiple jobs together:


### PR DESCRIPTION
Added examples from the stereoTop workflow. Removed some bits of the original examples but kept some as reference. Showed how definitions and rules work and how we implemented them. Showed how makeflow files use singularity to access extractors and basics on how one might implement their own extractors. Kept the last part in tact.